### PR TITLE
harden: the bitbucket connector uses http basic authent... in...

### DIFF
--- a/plugins/catalog/bitbucket.py
+++ b/plugins/catalog/bitbucket.py
@@ -53,9 +53,9 @@ def get_bitbucket_contents(repo):
         api_url = f"https://api.bitbucket.org/2.0/repositories/{repo_owner}/{repo_slug}/src/{branch}/"
 
     if repo.token:
-        response = requests.get(api_url, auth=HTTPBasicAuth(repo_owner, repo.token), proxies=PROXY)
+        response = requests.get(api_url, auth=HTTPBasicAuth(repo_owner, repo.token), proxies=PROXY, timeout=30)
     else:
-        response = requests.get(api_url, proxies=PROXY)
+        response = requests.get(api_url, proxies=PROXY, timeout=30)
     
     if response.status_code == 200:
         data = response.json()
@@ -69,10 +69,13 @@ def get_bitbucket_contents(repo):
         # Bitbucket is paginating results. The "next" key returns the URL of the next page results
         while "next" in response.json():
             api_url = response.json()["next"]
+            if not api_url.startswith("https://"):
+                add_error_notification(f"Bitbucket connector: refusing to follow non-HTTPS pagination URL")
+                break
             if repo.token:
-                response = requests.get(api_url, auth=HTTPBasicAuth(repo_owner, repo.token), proxies=PROXY)
+                response = requests.get(api_url, auth=HTTPBasicAuth(repo_owner, repo.token), proxies=PROXY, timeout=30)
             else:
-                response = requests.get(api_url, proxies=PROXY)
+                response = requests.get(api_url, proxies=PROXY, timeout=30)
             data = response.json()
             for item in data.get('values'):
                 if item['type'] == 'commit_file' and Path(item['path']).suffix == ".json":


### PR DESCRIPTION
## Summary
Harden input handling in `plugins/catalog/bitbucket.py` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `plugins/catalog/bitbucket.py:54` |
| **Assessment** | Defensive hardening |
| **Chain Complexity** | 2-step |

**Description**: The Bitbucket connector uses HTTP Basic Authentication to authenticate against the Bitbucket API. While the primary endpoint uses HTTPS, the code does not enforce TLS verification or explicitly reject HTTP URLs. The api_url is constructed from user-configurable repo.url, and pagination next URLs from API responses are used without HTTPS validation, creating potential credential exposure risks.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `plugins/catalog/bitbucket.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
